### PR TITLE
Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tap-spec": "^2.1.2"
   },
   "scripts": {
-    "test": "node test/main.js | ./node_modules/tap-spec/bin/cmd.js"
+    "test": "node test/main.js | node ./node_modules/tap-spec/bin/cmd.js"
   },
   "author": "Clément Delafargue <clement@delafargue.name>",
   "license": "MIT",

--- a/src/cli.js
+++ b/src/cli.js
@@ -27,7 +27,7 @@ cli.cli = function(options, cb) {
     options,
     cb
   );
-}
+};
 
 cli.displayVersion = function(cli) {
   console.log(cli.version !== null ? cli.version : 'N/A');
@@ -116,7 +116,8 @@ cli.parse = function(cliApp, argv) {
   var options = _.omit(cliValues, "_");
   var args = cliValues._;
 
-  if(args[0] === "node") {
+  // check the command is launch via the node interpreter (+ ensure windows compat)
+  if (args[0].match(/node[\.exe]*$/)) {
     args = _.drop(args, 2);
   } else {
     args = _.drop(args, 1);


### PR DESCRIPTION
Hi Clement,
As proposed during your Human Talk last tuesday, here it comes : tests and sample now run on Windows (and WebStorm).
Nothing broken hopefully on linux (as Travis build is OK, https://travis-ci.org/ObjectIsAdvantag/cliparse-node/builds)
Regards
Stève
