### PR TITLE
fix README example to run

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,18 @@ npm install cliparse
 ```
 
 ```javascript
+#!/usr/bin/env node
+
 var cliparse = require("cliparse");
 var parsers = cliparse.parsers;
+
+function echoModule(args, options) {
+    
+}
+
+function addModule(args, options) {
+    
+}
 
 var cliParser = cliparse.cli({
   name: "my-executable",
@@ -50,7 +60,7 @@ var cliParser = cliparse.cli({
   ]
 });
 
-cliparse.parse(testCli);
+cliparse.parse(cliParser);
 ```
 
 Where `echoModule` and `addModule` are callbacks taking a `{ args: ['value'], options: {key: 'value'} }` parameter.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ npm install cliparse
 var cliparse = require("cliparse");
 var parsers = cliparse.parsers;
 
-function echoModule(args, options) {
+function echoModule(params) {
     
 }
 
-function addModule(args, options) {
+function addModule(params) {
     
 }
 


### PR DESCRIPTION
This modifies README.md so that the example code runs.
adds undefined echoModule, addModule
fixes broken reference to cliParser
