### PR TITLE
Display default values in help

### DIFF
--- a/src/argument.js
+++ b/src/argument.js
@@ -54,7 +54,9 @@ argument.usage = function(argument) {
 };
 
 argument.help = function(arg) {
-  return [argument.usage(arg), arg.description];
+  var description = arg.description;
+  if(arg.default !== null) description += " (default: " + arg.default + ")";
+  return [argument.usage(arg), description];
 };
 
 argument.complete = function(arg, word) {

--- a/src/option.js
+++ b/src/option.js
@@ -60,7 +60,7 @@ option.help = function(opt) {
   if(opt.metavar) output += ' ' + opt.metavar.toUpperCase();
   if(opt.default !== null) description += " (default: " + opt.default + ")";
 
-  return [output, description];
+  return [output, description.trim()];
 };
 
 option.usage = function(opt) {

--- a/src/option.js
+++ b/src/option.js
@@ -56,8 +56,11 @@ option.parseObject = function(options, providedOptions) {
 
 option.help = function(opt) {
   var output = option.displayOptionNames(opt.names, opt.required, true);
+  var description = opt.description;
   if(opt.metavar) output += ' ' + opt.metavar.toUpperCase();
-  return [output, opt.description];
+  if(opt.default !== null) description += " (default: " + opt.default + ")";
+
+  return [output, description];
 };
 
 option.usage = function(opt) {


### PR DESCRIPTION
Display default values (if defined) for options and arguments in help text.
Fixes #13
