### PR TITLE
Handle "false" and "true" in booleanParser

### DIFF
--- a/src/parsers.js
+++ b/src/parsers.js
@@ -28,9 +28,17 @@ parsers.booleanParser = function(value) {
   // minimist autoparses stuff anyway…
   if(typeof value === 'boolean') {
     return parsers.success(value);
-  } else {
-    return parsers.error("invalid boolean: " + value);
   }
+
+  if(value === 'false'){
+    return parsers.success(false);
+  }
+
+  if(value === 'true'){
+    return parsers.success(true);
+  }
+  
+  return parsers.error("invalid boolean: " + value);
 };
 
 parsers.existingPathParser = function(value) {

--- a/test/parsers.js
+++ b/test/parsers.js
@@ -67,6 +67,17 @@ test('booleanParser is noop for booleans', function(t) {
     t.same(result2, { success: input2 }, 'false');
 });
 
+test('booleanParser handles and converts string booleans', function(t) {
+    var input = 'true';
+    var input2 = 'false';
+    var result = parsers.booleanParser(input);
+    var result2 = parsers.booleanParser(input2);
+
+    t.plan(2);
+    t.same(result, { success: true }, 'true');
+    t.same(result2, { success: false }, 'false');
+});
+
 /*
  * fileParser
  */


### PR DESCRIPTION
When running a command like this : ./my-command --debug=true , for example,
the booleanParser returns an error (saying the value "true" is not a boolean, which is right).
I've done some (quick) investigation, and real boolean are not handled properly by the shell :/

So i've quickly patched your tool.
If there's a better way to do it, I'd like to learn about it (really).