### PR TITLE
Recurse on all nested commands

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -180,9 +180,18 @@ command.helpCommand = function() {
   return c;
 }();
 
+function getCommandsOfCommand(command) {
+  return _.reduce(command.commands, (commands, command) => {
+    if (command.commands.length > 0) {
+      return commands.concat(getCommandsOfCommand(command));
+    } else {
+      return commands.concat([command]);
+    }
+  }, [command]);
+}
+
 command.getFlagNames = function(cmd) {
-  return _([cmd])
-    .concat(cmd.commands)
+  return _(getCommandsOfCommand(cmd))
     .flatMap('options')
     .reject(function(opt) { return opt.expects_value; })
     .flatMap('names')
@@ -190,10 +199,8 @@ command.getFlagNames = function(cmd) {
     .value()
 };
 
-
 command.getOptionNames = function (cmd) {
-  return _([cmd])
-    .concat(cmd.commands)
+  return _(getCommandsOfCommand(cmd))
     .flatMap('options')
     .filter(function(opt) { return opt.expects_value; })
     .flatMap('names')

--- a/test/command.js
+++ b/test/command.js
@@ -54,35 +54,53 @@ test('command with arguments', function(t) {
 });
 
 test('retrieve flags', function(t) {
-  t.plan(2);
+  t.plan(3);
   var flag1 = cliparse.flag('flag-one');
   var flag2 = cliparse.flag('flag-two', { aliases: ["f"] });
+  var flag3 = cliparse.flag('flag-three', { aliases: ["x"]});
   var option1 = cliparse.option('opt-one');
   var option2 = cliparse.option('opt-two', { aliases: ["o"] });
+  var option3 = cliparse.option('opt-three', { aliases: ["t"]});
   var cmd1 = cliparse.command('name', { options: [flag1, option2]});
   var cmd2 = cliparse.command('name', { options: [flag1, option1], commands: [ cliparse.command('inner', { options: [flag2, option2] })]});
+  var cmd3 = cliparse.command('name', { options: [flag1, option1], commands: [
+    cliparse.command('inner', { options: [flag2, option2], commands: [
+        cliparse.command('second-inner', { options: [flag3, option3] }),
+    ]})
+  ]});
 
   var r1 = command.getFlagNames(cmd1);
   var r2 = command.getFlagNames(cmd2);
+  var r3 = command.getFlagNames(cmd3);
 
   t.same(r1, ['flag-one'], 'simple command');
   t.same(r2, ['flag-one', 'flag-two', 'f'], 'nested commands');
+  t.same(r3, ['flag-one', 'flag-two', 'f', 'flag-three', 'x'], 'nested commands two levels');
 });
 
 test('retrieve option names', function(t) {
-    t.plan(2);
+    t.plan(3);
     var flag1 = cliparse.flag('flag-one');
     var flag2 = cliparse.flag('flag-two', { aliases: ["f"] });
+    var flag3 = cliparse.flag('flag-three', { aliases: ["x"]});
     var option1 = cliparse.option('opt-one');
     var option2 = cliparse.option('opt-two', { aliases: ["o"] });
+    var option3 = cliparse.option('opt-three', { aliases: ["t"]});
     var cmd1 = cliparse.command('name', { options: [flag1, option2]});
     var cmd2 = cliparse.command('name', { options: [flag1, option1], commands: [ cliparse.command('inner', { options: [flag2, option2] })]});
+    var cmd3 = cliparse.command('name', { options: [flag1, option1], commands: [
+        cliparse.command('inner', { options: [flag2, option2], commands: [
+            cliparse.command('second-inner', { options: [flag3, option3] }),
+        ]})
+    ]});
 
     var r1 = command.getOptionNames(cmd1);
     var r2 = command.getOptionNames(cmd2);
+    var r3 = command.getOptionNames(cmd3);
 
     t.same(r1, ['opt-two', 'o'], 'simple command');
     t.same(r2, ['opt-one', 'opt-two', 'o'], 'nested commands');
+    t.same(r3, ['opt-one', 'opt-two', 'o', 'opt-three', 't'], 'nested commands two levels');
 });
 
 test('command with unknown options', function(t) {


### PR DESCRIPTION
The fix in 015dc1f058080f0b68e1027be46cb0473bdcdfc7 isn't complete,
leading the second level and deeper of nested commands to be ignored,
leading to minimist coercing string to numbers for those ignored.

This patch now recurses through all nested commands to fix this.